### PR TITLE
Cleanup

### DIFF
--- a/kubeauthconfig/kube-admin-user.yml
+++ b/kubeauthconfig/kube-admin-user.yml
@@ -1,37 +1,78 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_config_directory }}"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: "{{ k8s_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-auth-config-admin
+
     - name: Get IP address of first host in k8s_controller group and use as API server
       set_fact:
-        apiServer: |
-          {% set item = groups["k8s_controller"][0] %}
-          {{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
-      tags:
-        - kubernetes-ca
-
-    - name: Remove newline from API server IP address
-      set_fact:
-        apiServer: "{{apiServer |replace('\n', '')}}"
+        apiServer: >-
+          {% set item = groups["k8s_controller"][0] %}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
       tags:
         - k8s-auth-config-admin
 
     - name: Generate a kubeconfig file for the admin user (set-cluster)
-      shell: "kubectl config set-cluster {{k8s_config_cluster_name}} --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem --embed-certs=true --server=https://{{apiServer}}:{{k8s_apiserver_secure_port}} --kubeconfig={{k8s_config_directory}}/admin.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
+          --embed-certs=true \
+          --server=https://{{ apiServer }}:{{ k8s_apiserver_secure_port }} \
+          --kubeconfig={{ k8s_config_directory }}/admin.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-admin
 
     - name: Generate a kubeconfig file for the admin user (set-credentials)
-      shell: "kubectl config set-credentials admin --client-certificate={{k8s_ca_conf_directory}}/cert-admin.pem --client-key={{k8s_ca_conf_directory}}/cert-admin-key.pem --embed-certs=true --kubeconfig={{k8s_config_directory}}/admin.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-credentials admin \
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-admin.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-admin-key.pem \
+          --embed-certs=true \
+          --kubeconfig={{ k8s_config_directory }}/admin.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-admin
 
     - name: Generate a kubeconfig file for the admin user (set-context)
-      shell: "kubectl config set-context default --cluster={{k8s_config_cluster_name}} --user=admin --kubeconfig={{k8s_config_directory}}/admin.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-context default \
+          --cluster={{ k8s_config_cluster_name }} \
+          --user=admin \
+          --kubeconfig={{ k8s_config_directory }}/admin.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-admin
 
     - name: Set use-context
-      shell: "kubectl config use-context default --kubeconfig={{k8s_config_directory}}/admin.kubeconfig"
+      shell: >
+        kubectl config use-context default \
+          --kubeconfig={{ k8s_config_directory }}/admin.kubeconfig
+      args:
+        executable: /bin/bash
+      tags:
+        - k8s-auth-config-admin
+
+    - name: Set file permissions
+      file:
+        path: "{{ k8s_config_directory }}/admin.kubeconfig"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: '{{ k8s_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
       tags:
         - k8s-auth-config-admin

--- a/kubeauthconfig/kube-controller-manager.yml
+++ b/kubeauthconfig/kube-controller-manager.yml
@@ -1,37 +1,79 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_config_directory }}"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: "{{ k8s_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-auth-config-kublet
+
     - name: Get IP address of first host in k8s_controller group and use as API server
       set_fact:
-        apiServer: |
-          {% set item = groups["k8s_controller"][0] %}
-          {{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
+        apiServer: >-
+          {% set item = groups["k8s_controller"][0] %}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
       tags:
         - kubernetes-ca
 
-    - name: Remove newline from API server IP address
-      set_fact:
-        apiServer: "{{apiServer |replace('\n', '')}}"
-      tags:
-        - k8s-auth-config-controller-manager
-
     - name: Generate a kubeconfig file for the kube-controller-manager service (set-cluster)
-      shell: "kubectl config set-cluster {{k8s_config_cluster_name}} --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem --embed-certs=true --server=https://{{apiServer}}:{{k8s_apiserver_secure_port}} --kubeconfig={{k8s_config_directory}}/kube-controller-manager.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
+          --embed-certs=true \
+          --server=https://{{ apiServer }}:{{ k8s_apiserver_secure_port }} \
+          --kubeconfig={{ k8s_config_directory }}/kube-controller-manager.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-controller-manager
 
     - name: Generate a kubeconfig file for the kube-controller-manager service (set-credentials)
-      shell: "kubectl config set-credentials system:kube-controller-manager --client-certificate={{k8s_ca_conf_directory}}/cert-k8s-controller-manager.pem --client-key={{k8s_ca_conf_directory}}/cert-k8s-controller-manager-key.pem --embed-certs=true --kubeconfig={{k8s_config_directory}}/kube-controller-manager.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config set-credentials system:kube-controller-manager \
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-k8s-controller-manager.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-k8s-controller-manager-key.pem \
+          --embed-certs=true \
+          --kubeconfig={{ k8s_config_directory }}/kube-controller-manager.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-controller-manager
 
     - name: Generate a kubeconfig file for the kube-controller-manager service (set-context)
-      shell: "kubectl config set-context default --cluster={{k8s_config_cluster_name}} --user=system:kube-controller-manager --kubeconfig={{k8s_config_directory}}/kube-controller-manager.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config set-context default \
+          --cluster={{ k8s_config_cluster_name }} \
+          --user=system:kube-controller-manager \
+          --kubeconfig={{ k8s_config_directory }}/kube-controller-manager.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-controller-manager
 
     - name: Set use-context
-      shell: "kubectl config use-context default --kubeconfig={{k8s_config_directory}}/kube-controller-manager.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config use-context default \
+          --kubeconfig={{ k8s_config_directory }}/kube-controller-manager.kubeconfig
+      args:
+        executable: /bin/bash
+      tags:
+        - k8s-auth-config-controller-manager
+
+    - name: Set file permissions
+      file:
+        path: "{{ k8s_config_directory }}/kube-controller-manager.kubeconfig"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: '{{ k8s_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
       tags:
         - k8s-auth-config-controller-manager

--- a/kubeauthconfig/kube-proxy.yml
+++ b/kubeauthconfig/kube-proxy.yml
@@ -1,37 +1,77 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_config_directory }}"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: "{{ k8s_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-auth-config-proxy
+
     - name: Get IP address of first host in k8s_controller group and use as API server
       set_fact:
-        apiServer: |
-          {% set item = groups["k8s_controller"][0] %}
-          {{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
-      tags:
-        - kubernetes-ca
-
-    - name: Remove newline from API server IP address
-      set_fact:
-        apiServer: "{{apiServer |replace('\n', '')}}"
+        apiServer: >-
+          {% set item = groups["k8s_controller"][0] %}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
       tags:
         - k8s-auth-config-proxy
 
     - name: Generate a kubeconfig file for the kube-proxy service (set-cluster)
-      shell: "kubectl config set-cluster {{k8s_config_cluster_name}} --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem --embed-certs=true --server=https://{{apiServer}}:{{k8s_apiserver_secure_port}} --kubeconfig={{k8s_config_directory}}/kube-proxy.kubeconfig"
+      shell: >
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
+          --embed-certs=true \
+          --server=https://{{ apiServer }}:{{ k8s_apiserver_secure_port }} \
+          --kubeconfig={{ k8s_config_directory }}/kube-proxy.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-proxy
 
     - name: Generate a kubeconfig file for the kube-proxy service (set-credentials)
-      shell: "kubectl config set-credentials system:kube-proxy --client-certificate={{k8s_ca_conf_directory}}/cert-k8s-proxy.pem --client-key={{k8s_ca_conf_directory}}/cert-k8s-proxy-key.pem --embed-certs=true --kubeconfig={{k8s_config_directory}}/kube-proxy.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-credentials system:kube-proxy \
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-k8s-proxy.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-k8s-proxy-key.pem \
+          --embed-certs=true \
+          --kubeconfig={{ k8s_config_directory }}/kube-proxy.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-proxy
 
     - name: Generate a kubeconfig file for the kube-proxy service (set-context)
-      shell: "kubectl config set-context default --cluster={{k8s_config_cluster_name}} --user=system:kube-proxy --kubeconfig={{k8s_config_directory}}/kube-proxy.kubeconfig"
+      shell: >
+        kubectl config set-context default \
+          --cluster={{ k8s_config_cluster_name }} \
+          --user=system:kube-proxy \
+          --kubeconfig={{ k8s_config_directory }}/kube-proxy.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-proxy
 
     - name: Set use-context
-      shell: "kubectl config use-context default --kubeconfig={{k8s_config_directory}}/kube-proxy.kubeconfig"
+      shell: >
+        kubectl config use-context default \
+          --kubeconfig={{ k8s_config_directory }}/kube-proxy.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-proxy
+
+    - name: Set file permissions
+      file:
+        path: "{{ k8s_config_directory }}/kube-proxy.kubeconfig"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: '{{ k8s_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
+      tags:
+        - k8s-auth-config-kubelet
+

--- a/kubeauthconfig/kube-scheduler.yml
+++ b/kubeauthconfig/kube-scheduler.yml
@@ -1,37 +1,79 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_config_directory }}"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: "{{ k8s_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-auth-config-scheduler
+
     - name: Get IP address of first host in k8s_controller group and use as API server
       set_fact:
-        apiServer: |
-          {% set item = groups["k8s_controller"][0] %}
-          {{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
-      tags:
-        - kubernetes-ca
-
-    - name: Remove newline from API server IP address
-      set_fact:
-        apiServer: "{{apiServer |replace('\n', '')}}"
+        apiServer: >-
+          {% set item = groups["k8s_controller"][0] %}{{ hostvars[item]["ansible_"+hostvars[item]["k8s_interface"]].ipv4.address }}
       tags:
         - k8s-auth-config-scheduler
 
     - name: Generate a kubeconfig file for the kube-scheduler service (set-cluster)
-      shell: "kubectl config set-cluster {{k8s_config_cluster_name}} --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem --embed-certs=true --server=https://{{apiServer}}:{{k8s_apiserver_secure_port}} --kubeconfig={{k8s_config_directory}}/kube-scheduler.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
+          --embed-certs=true \
+          --server=https://{{ apiServer }}:{{ k8s_apiserver_secure_port }} \
+          --kubeconfig={{ k8s_config_directory }}/kube-scheduler.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-scheduler
 
     - name: Generate a kubeconfig file for the kube-scheduler service (set-credentials)
-      shell: "kubectl config set-credentials system:kube-scheduler --client-certificate={{k8s_ca_conf_directory}}/cert-k8s-scheduler.pem --client-key={{k8s_ca_conf_directory}}/cert-k8s-scheduler-key.pem --embed-certs=true --kubeconfig={{k8s_config_directory}}/kube-scheduler.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config set-credentials system:kube-scheduler \
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-k8s-scheduler.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-k8s-scheduler-key.pem \
+          --embed-certs=true \
+          --kubeconfig={{ k8s_config_directory }}/kube-scheduler.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-scheduler
 
     - name: Generate a kubeconfig file for the kube-scheduler service (set-context)
-      shell: "kubectl config set-context default --cluster={{k8s_config_cluster_name}} --user=system:kube-scheduler --kubeconfig={{k8s_config_directory}}/kube-scheduler.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config set-context default \
+          --cluster={{ k8s_config_cluster_name }} \
+          --user=system:kube-scheduler \
+          --kubeconfig={{ k8s_config_directory }}/kube-scheduler.kubeconfig
+      args:
+        executable: /bin/bash
       tags:
         - k8s-auth-config-scheduler
 
     - name: Set use-context
-      shell: "kubectl config use-context default --kubeconfig={{k8s_config_directory}}/kube-scheduler.kubeconfig"
+      shell:
+        set -o errexit; \
+        kubectl config use-context default \
+          --kubeconfig={{ k8s_config_directory }}/kube-scheduler.kubeconfig
+      args:
+        executable: /bin/bash
+      tags:
+        - k8s-auth-config-scheduler
+
+    - name: Set file permissions
+      file:
+        path: "{{ k8s_config_directory }}/kube-scheduler.kubeconfig"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: '{{ k8s_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
       tags:
         - k8s-auth-config-scheduler

--- a/kubeauthconfig/kubelets.yml
+++ b/kubeauthconfig/kubelets.yml
@@ -68,7 +68,7 @@
       tags:
         - k8s-auth-config-kubelet
 
-    - name: Set file permissions 
+    - name: Set file permissions
       file:
         path: "{{ k8s_config_directory }}/{{ item }}.kubeconfig"
         owner: "{{ k8s_config_owner }}"

--- a/kubeauthconfig/kubelets.yml
+++ b/kubeauthconfig/kubelets.yml
@@ -1,31 +1,83 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_config_directory }}"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: "{{ k8s_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-auth-config-kublet
+
     - name: Generate a kubeconfig file for each worker node (set-cluster)
-      shell: "kubectl config set-cluster {{k8s_config_cluster_name}} --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem --embed-certs=true --server=https://{{hostvars[groups['k8s_controller'][0]]['ansible_'+hostvars[item]['k8s_interface']].ipv4.address}}:{{k8s_apiserver_secure_port}} --kubeconfig={{k8s_config_directory}}/{{item}}.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
+          --embed-certs=true \
+          --server=https://{{ hostvars[groups['k8s_controller'][0]]['ansible_'+hostvars[item]['k8s_interface']].ipv4.address }}:{{ k8s_apiserver_secure_port }} \
+          --kubeconfig={{ k8s_config_directory }}/{{ item }}.kubeconfig
+      args:
+        executable: /bin/bash
       with_inventory_hostnames:
         - k8s_worker
       tags:
         - k8s-auth-config-kubelet
 
     - name: Generate a kubeconfig file for each worker node (set-credentials)
-      shell: "kubectl config set-credentials system:node:{{hostvars[item]['ansible_hostname']}} --client-certificate={{k8s_ca_conf_directory}}/cert-{{item}}.pem --client-key={{k8s_ca_conf_directory}}/cert-{{item}}-key.pem --embed-certs=true --kubeconfig={{k8s_config_directory}}/{{item}}.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-credentials system:node:{{hostvars[item]['ansible_hostname']}} \
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-{{ item }}.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-{{ item }}-key.pem \
+          --embed-certs=true \
+          --kubeconfig={{ k8s_config_directory }}/{{ item }}.kubeconfig
+      args:
+        executable: /bin/bash
       with_inventory_hostnames:
         - k8s_worker
       tags:
         - k8s-auth-config-kubelet
 
     - name: Generate a kubeconfig file for each worker node (set-context)
-      shell: "kubectl config set-context default --cluster={{k8s_config_cluster_name}} --user=system:node:{{hostvars[item]['ansible_hostname']}} --kubeconfig={{k8s_config_directory}}/{{item}}.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config set-context default \
+          --cluster={{ k8s_config_cluster_name }} \
+          --user=system:node:{{ hostvars[item]['ansible_hostname'] }} \
+          --kubeconfig={{ k8s_config_directory }}/{{ item }}.kubeconfig
+      args:
+        executable: /bin/bash
       with_inventory_hostnames:
         - k8s_worker
       tags:
         - k8s-auth-config-kubelet
 
     - name: Set use-context
-      shell: "kubectl config use-context default --kubeconfig={{k8s_config_directory}}/{{item}}.kubeconfig"
+      shell: >
+        set -o errexit; \
+        kubectl config use-context default \
+          --kubeconfig={{ k8s_config_directory }}/{{ item }}.kubeconfig
+      args:
+        executable: /bin/bash
       with_inventory_hostnames:
         - k8s_worker
       tags:
         - k8s-auth-config-kubelet
+
+    - name: Set file permissions 
+      file:
+        path: "{{ k8s_config_directory }}/{{ item }}.kubeconfig"
+        owner: "{{ k8s_config_owner }}"
+        group: "{{ k8s_config_group }}"
+        mode: '{{ k8s_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
+      with_inventory_hostnames:
+        - k8s_worker
+      tags:
+        - k8s-auth-config-kubelet
+

--- a/kubectlconfig/kubectlconfig.yml
+++ b/kubectlconfig/kubectlconfig.yml
@@ -1,43 +1,47 @@
 ---
 
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
     - name: kubectl config set-cluster
-      shell: |
-        kubectl config set-cluster {{k8s_config_cluster_name}} \
-          --certificate-authority={{k8s_ca_conf_directory}}/ca-k8s-apiserver.pem \
+      shell: >
+        set -o errexit; \
+        kubectl config set-cluster {{ k8s_config_cluster_name }} \
+          --certificate-authority={{ k8s_ca_conf_directory }}/ca-k8s-apiserver.pem \
           --embed-certs=true \
-          --server=https://{{hostvars[groups.k8s_controller|first]['ansible_' + k8s_interface].ipv4.address}}:6443
+          --server=https://{{ hostvars[groups.k8s_controller|first]['ansible_' + k8s_interface].ipv4.address }}:6443
       register: set_cluster
 
     - debug:
-        msg: "COMMAND:{{set_cluster.cmd}} | OUTPUT: {{set_cluster.stdout}}"
+        msg: "COMMAND:{{ set_cluster.cmd }} | OUTPUT: {{ set_cluster.stdout }}"
 
     - name: kubectl config set-credentials admin
-      shell: |
+      shell: >
+        set -o errexit; \
         kubectl config set-credentials admin \
-          --client-certificate={{k8s_ca_conf_directory}}/cert-admin.pem \
-          --client-key={{k8s_ca_conf_directory}}/cert-admin-key.pem
+          --client-certificate={{ k8s_ca_conf_directory }}/cert-admin.pem \
+          --client-key={{ k8s_ca_conf_directory }}/cert-admin-key.pem
       register: set_credentials
 
     - debug:
-        msg: "COMMAND:{{set_credentials.cmd}} | OUTPUT: {{set_credentials.stdout}}"
+        msg: "COMMAND:{{ set_credentials.cmd }} | OUTPUT: {{ set_credentials.stdout }}"
 
     - name: kubectl config set-context
-      shell: |
-        kubectl config set-context {{k8s_config_cluster_name}} \
-          --cluster={{k8s_config_cluster_name}} \
+      shell: >
+        set -o errexit; \
+        kubectl config set-context {{ k8s_config_cluster_name }} \
+          --cluster={{ k8s_config_cluster_name }} \
           --user=admin
       register: set_context
 
     - debug:
-        msg: "COMMAND:{{set_context.cmd}} | OUTPUT: {{set_context.stdout}}"
+        msg: "COMMAND:{{ set_context.cmd }} | OUTPUT: {{ set_context.stdout }}"
 
     - name: kubectl config use-context
-      shell: |
-        kubectl config use-context {{k8s_config_cluster_name}}
+      shell: >
+        set -o errexit; \
+        kubectl config use-context {{ k8s_config_cluster_name }}
       register: use_context
 
     - debug:
-        msg: "COMMAND:{{use_context.cmd}} | OUTPUT: {{use_context.stdout}}"
+        msg: "COMMAND:{{ use_context.cmd }} | OUTPUT: {{ use_context.stdout }}"

--- a/kubeencryptionconfig/kubeencryptionconfig.yml
+++ b/kubeencryptionconfig/kubeencryptionconfig.yml
@@ -2,11 +2,31 @@
 - hosts: localhost
 
   tasks:
+    - name: Create directory for kubeconfig files
+      file:
+        path: "{{ k8s_encryption_config_directory }}"
+        owner: "{{ k8s_encryption_config_owner }}"
+        group: "{{ k8s_encryption_config_group }}"
+        mode: "{{ k8s_encryption_config_directory_perm }}"
+        state: directory
+      tags:
+        - k8s-encrypt-conf
+
     - name: Create encryption config file
       template:
         src: "templates/encryption-config.yaml.j2"
         dest: "{{ k8s_encryption_config_directory }}/encryption-config.yaml"
         mode: 0600
       tags:
-        - Create encryption config file
+        - k8s-encrypt-conf
 
+    - name: Set file permissions
+      file:
+        path: "{{ k8s_encryption_config_directory }}/encryption-config.yaml"
+        owner: "{{ k8s_encryption_config_owner }}"
+        group: "{{ k8s_encryption_config_group }}"
+        mode: '{{ k8s_encryption_config_file_perm }}'
+        modification_time: "preserve"
+        access_time: "preserve"
+      tags:
+        - k8s-encrypt-conf

--- a/kubeencryptionconfig/kubeencryptionconfig.yml
+++ b/kubeencryptionconfig/kubeencryptionconfig.yml
@@ -1,11 +1,11 @@
 ---
-- hosts: k8s_kubectl
+- hosts: localhost
 
   tasks:
     - name: Create encryption config file
       template:
         src: "templates/encryption-config.yaml.j2"
-        dest: "{{k8s_encryption_config_directory}}/encryption-config.yaml"
+        dest: "{{ k8s_encryption_config_directory }}/encryption-config.yaml"
         mode: 0600
       tags:
         - Create encryption config file

--- a/kubeencryptionconfig/templates/encryption-config.yaml.j2
+++ b/kubeencryptionconfig/templates/encryption-config.yaml.j2
@@ -7,5 +7,5 @@ resources:
       - aescbc:
           keys:
             - name: key1
-              secret: {{k8s_encryption_config_key}}
+              secret: {{ k8s_encryption_config_key }}
       - identity: {}


### PR DESCRIPTION
- mainly better formatting of shell scripts
- replaced `hosts: k8s_kubectl` with `hosts: localhost` as `kubectl` command runs locally anyways.
- introduce new variables: `k8s_config_directory_perm`, `k8s_config_file_perm`, `k8s_config_owner` and `k8s_config_group`. Allows to setup directory and file permissions as needed.