### PR TITLE
CoreDNS v1.8.4

### DIFF
--- a/coredns/templates/clusterrole.yml.j2
+++ b/coredns/templates/clusterrole.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   labels:
@@ -8,7 +8,9 @@ metadata:
 rules:
 - apiGroups:
   - ""
+  - discovery.k8s.io
   resources:
+  - endpointslices
   - endpoints
   - services
   - pods

--- a/coredns/templates/clusterrolebinding.yml.j2
+++ b/coredns/templates/clusterrolebinding.yml.j2
@@ -1,5 +1,5 @@
 ---
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   annotations:

--- a/coredns/templates/deployment.yml.j2
+++ b/coredns/templates/deployment.yml.j2
@@ -29,7 +29,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.7.0
+        image: coredns/coredns:1.8.4
         imagePullPolicy: IfNotPresent
         resources:
           limits:


### PR DESCRIPTION
- update `CoreDNS` to `v1.8.4`
- update `CoreDNS` permissions needed for K8s >= 1.19 / change `rbac.authorization.k8s.io/v1beta1` to `v1`

