### PR TITLE
v15.0.0_r1.27.5

### DIFF
--- a/coredns/README.md
+++ b/coredns/README.md
@@ -6,6 +6,7 @@ This playbook is used in my blog post [Kubernetes the not so hard way with Ansib
 This playbook uses the Ansible's [k8s](https://docs.ansible.com/ansible/2.6/modules/k8s_module.html) module. That means you need at least Ansible v2.6 as it was added with this version (the module was formerly known as `openshift_raw` or `k8s_raw` ;-) ). This modules uses the OpenShift Python client to perform CRUD operations on Kubernetes objects. That means you need to install `openshift` pip e.g.: `pip3 install openshift` (also see [requirements](https://docs.ansible.com/ansible/2.6/modules/k8s_module.html#requirements).
 
 Before you install and use CoreDNS for your Kubernetes cluster you may find this links useful:  
+[CoreDNS version in Kubernetes](https://github.com/coredns/deployment/blob/master/kubernetes/CoreDNS-k8s_version.md)
 [CoreDNS GA for Kubernetes Cluster DNS](https://kubernetes.io/blog/2018/07/10/coredns-ga-for-kubernetes-cluster-dns/)  
 [Customizing DNS Service](https://kubernetes.io/docs/tasks/administer-cluster/dns-custom-nameservers/)  
 [Migration from kube-dns to CoreDNS](https://coredns.io/2018/05/21/migration-from-kube-dns-to-coredns/)  

--- a/coredns/coredns.yml
+++ b/coredns/coredns.yml
@@ -1,6 +1,6 @@
 ---
 - name: Run CoreDNS playbook
-  hosts: k8s_kubectl
+  hosts: localhost
   tasks:
     - name: Set default action
       set_fact:

--- a/coredns/templates/clusterrole.yml.j2
+++ b/coredns/templates/clusterrole.yml.j2
@@ -6,15 +6,20 @@ metadata:
     kubernetes.io/bootstrapping: rbac-defaults
   name: system:coredns
 rules:
-- apiGroups:
-  - ""
-  - discovery.k8s.io
-  resources:
-  - endpointslices
-  - endpoints
-  - services
-  - pods
-  - namespaces
-  verbs:
-  - list
-  - watch
+  - apiGroups:
+    - ""
+    resources:
+    - endpoints
+    - services
+    - pods
+    - namespaces
+    verbs:
+    - list
+    - watch
+  - apiGroups:
+    - discovery.k8s.io
+    resources:
+    - endpointslices
+    verbs:
+    - list
+    - watch

--- a/coredns/templates/deployment.yml.j2
+++ b/coredns/templates/deployment.yml.j2
@@ -23,6 +23,7 @@ spec:
         k8s-app: kube-dns
         app.kubernetes.io/name: coredns
     spec:
+      priorityClassName: system-cluster-critical
       serviceAccountName: coredns
       tolerations:
         - key: node-role.kubernetes.io/master

--- a/coredns/templates/deployment.yml.j2
+++ b/coredns/templates/deployment.yml.j2
@@ -29,7 +29,7 @@ spec:
           operator: "Exists"
       containers:
       - name: coredns
-        image: coredns/coredns:1.8.4
+        image: coredns/coredns:1.10.1
         imagePullPolicy: IfNotPresent
         resources:
           limits:

--- a/coredns/templates/deployment.yml.j2
+++ b/coredns/templates/deployment.yml.j2
@@ -16,12 +16,10 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
-      app.kubernetes.io/name: coredns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
-        app.kubernetes.io/name: coredns
     spec:
       priorityClassName: system-cluster-critical
       serviceAccountName: coredns

--- a/coredns/templates/deployment.yml.j2
+++ b/coredns/templates/deployment.yml.j2
@@ -16,10 +16,12 @@ spec:
   selector:
     matchLabels:
       k8s-app: kube-dns
+      app.kubernetes.io/name: coredns
   template:
     metadata:
       labels:
         k8s-app: kube-dns
+        app.kubernetes.io/name: coredns
     spec:
       serviceAccountName: coredns
       tolerations:

--- a/coredns/templates/service.yml.j2
+++ b/coredns/templates/service.yml.j2
@@ -11,9 +11,11 @@ metadata:
     k8s-app: kube-dns
     kubernetes.io/cluster-service: "true"
     kubernetes.io/name: "CoreDNS"
+    app.kubernetes.io/name: coredns
 spec:
   selector:
     k8s-app: kube-dns
+    app.kubernetes.io/name: coredns
   clusterIP: 10.32.0.254
   ports:
     - name: dnsudp

--- a/coredns/templates/service.yml.j2
+++ b/coredns/templates/service.yml.j2
@@ -15,7 +15,6 @@ metadata:
 spec:
   selector:
     k8s-app: kube-dns
-    app.kubernetes.io/name: coredns
   clusterIP: 10.32.0.254
   ports:
     - name: dnsudp

--- a/coredns/templates/service.yml.j2
+++ b/coredns/templates/service.yml.j2
@@ -24,3 +24,6 @@ spec:
     - name: dnstcp
       port: 53
       protocol: TCP
+    - name: metrics
+      port: 9153
+      protocol: TCP


### PR DESCRIPTION
- update CoreDNS to v1.10.1
- `README`: add link to `CoreDNS version in Kubernetes`
- `coredns/templates/clusterrole.yml.j2`: update `ClusterRole`
- `coredns/templates/service.yml.j2`: add metrics on port 9153
- `coredns/templates/deployment.yml.j2`: add `priorityClassName: system-cluster-critical`
- change `hosts: k8s_kubectl` to `hosts: localhost`